### PR TITLE
[🐸 Frogbot] Update version of django to 4.2.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask==1.1.2
 itsdangerous==1.1.0
 Jinja2==2.11.3
 Werkzeug==1.0.1
-Django==3.1.7
+django==4.2.24
 SQLAlchemy==2.0.36
 jeepney==0.8.0
 markupsafe==2.1.1


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![high](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | CVE-2021-33571 | Not Covered | django:3.1.7 | django 3.1.7 | [2.2.24]<br>[3.1.12]<br>[3.2.4] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallMedium.svg" alt=""/> Medium |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | django:3.1.7 |
| **Impacted Dependency:** | django:3.1.7 |
| **Fixed Versions:** | [2.2.24], [3.1.12], [3.2.4] |
| **CVSS V3:** | 7.5 |

Incorrect IP parsing in Django’s Python ipaddress module can lead to IP address confusion.

### 🔬 JFrog Research Details

**Description:**
Django is a Python-based free and open-source web framework that follows the model-template-views architectural pattern.

This CVE was cloned by the Django maintainers, while the underlying issue is exactly the same as CVE-2021-29921.

In Python's built-in `ipaddress` module, when parsing IPv4 strings, leading zeros are incorrectly ignored and are not assumed to specify octal (base 8) octets. IP addresses are left stripped instead of evaluated as valid octal IP addresses. This behavior is problematic since many other tools (such as Bash) can properly handle octal IP addresses.

An attacker can exploit this vulnerability if Python is used with the  `ipaddress.ip_address` or `ipaddress.ip_network` functions for parsing an IP address received as a string from user input.

The impact from this vulnerability is an IP address confusion between two different components:

1. Python’s `ipaddress` module which will misinterpret an octal IP address 
2. Some other IP address parser that correctly handles octal IP addresses, such as Bash. 

For example, in the following PoC the 1st `ping` invocation will access ip address "8.8.8.8" but the 2nd invocation will (incorrectly) access "10.8.8.8":

```
SUSPECT = '010.8.8.8'
BAD_IP = ipaddress.ip_address(SUSPECT)
subprocess.check_output("ping -W3 -v -c1 "+str(SUSPECT), shell=True, universal_newlines=True)
subprocess.check_output("ping -W3 -v -c1 "+str(BAD_IP), shell=True, universal_newlines=True)
```



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
